### PR TITLE
Fix Remnant salvage event trigger for 0.9.12

### DIFF
--- a/data/UPMissions.txt
+++ b/data/UPMissions.txt
@@ -1502,7 +1502,9 @@ mission "OSRemnantSalvage"
 	destination "Ursa Polaris Station"
 	to offer
 		has "event: UPS Remnant Outfits"
-		has "event: Remnant Salvage Available"
+		or
+			has "event: Remnant Salvage Available"
+			has "event: remnant salvage available"
 	on offer
 		event "UPS Remnant Salvage"
 		fail


### PR DESCRIPTION
The `Remnant Salvage Available` event name was changed to `remnant salvage available` in https://github.com/endless-sky/endless-sky/pull/4862 which went into Endless Sky 0.9.12.

(I've tested that this works in 0.9.12, but not earlier versions.)