### PR TITLE
Compatibility for new starts.

### DIFF
--- a/data/UPMissions.txt
+++ b/data/UPMissions.txt
@@ -18,7 +18,11 @@ mission "OS1"
 	destination Farpoint
 	passengers 1
 	to offer
-		has "Intro [0]: done"
+		or
+			has "Intro [0]: done"
+			has "Midgard Intro [0]: done"
+			has "Mainsail Intro [0]: done"
+			has "Delve Intro [0]: done"
 		has "event: pug flee"
 	npc waiting
 		system Rigel


### PR DESCRIPTION
Each of the 3 new Human starts has their own uniquely named intro mission chain. This would cause the first Ursa Polaris mission to never trigger when using one of them, since the condition "Intro [0]: done" would not be present. The broad strokes of each chain is the same and James ends up on Hestia in all of them so I just added an "or" statement and nested them all under it.

https://github.com/endless-sky/endless-sky/pull/11302